### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ servers.
         Credentials = new NetworkCredential("username", "password"),
     });
     
-    IEnumerable<Project> projects = new List<Project>();
-    Task.Run(async () =>
-    {
-        projects = await client.Project.GetProjects();
-    }).Wait();
+    var projects = client.Project.GetProjects().Result;
 
 ## Progress
 


### PR DESCRIPTION
Just a suggestion for brevity. If the intention is to block, calling `task.Result` can skip a lot of boilerplate code. It also allows for consistency around `var` usage.